### PR TITLE
Fix tests runnner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-test"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf10fe8d8fcdca0d69d961e2ffdc51b5101811649342078d4efa8ca2370fe17"
+dependencies = [
+ "defmt 1.0.1",
+ "embassy-executor",
+ "embedded-test-macros",
+ "heapless",
+ "semihosting",
+ "serde",
+ "serde-json-core",
+]
+
+[[package]]
+name = "embedded-test-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "832520ef06a9dd2970a9106f94aca45dc47b746d14dbecc0819a47a7b5c1b5be"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,6 +1311,7 @@ dependencies = [
  "embedded-hal-async",
  "embedded-hal-bus",
  "embedded-io-async",
+ "embedded-test",
  "esp-alloc",
  "esp-backtrace",
  "esp-bootloader-esp-idf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,11 @@ version = "0.1.0"
 [[bin]]
 name = "ptp-esp32"
 path = "./src/main.rs"
+harness = false
+
+[[test]]
+name = "integration"
+harness = false
 
 [features]
 ethernet = []
@@ -54,3 +59,6 @@ incremental      = false
 lto              = 'fat'
 opt-level        = 's'
 overflow-checks  = false
+
+[dev-dependencies]
+embedded-test = { version = "0.6.2", features = ["xtensa-semihosting", "defmt", "embassy", "external-executor"] }

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,7 @@ fn main() {
     println!("cargo:rustc-link-arg=-Tdefmt.x");
     // make sure linkall.x is the last linker script (otherwise might cause problems with flip-link)
     println!("cargo:rustc-link-arg=-Tlinkall.x");
+    println!("cargo::rustc-link-arg-tests=-Tembedded-test.x");
 }
 
 fn linker_be_nice() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,9 +1,7 @@
-//! Demo test suite using embedded-test
-//!
-//! You can run this using `cargo test` as usual.
-
 #![no_std]
 #![no_main]
+
+use {defmt as _, esp_println as _};
 
 #[cfg(test)]
 #[embedded_test::tests(executor = esp_hal_embassy::Executor::new())]


### PR DESCRIPTION
The standard Rust test runner won't work here, so we need to disable the harness and use embedded-test here. However, we need to make sure certain things are linked into our final binary or it won't work.